### PR TITLE
Fixed ESM conditional export

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,8 +109,8 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./lib/index.d.ts",
-        "default": "./lib/index.js"
+        "types": "./lib/App.d.ts",
+        "default": "./lib/App.js"
       }
     },
     "./*": {


### PR DESCRIPTION
The latest (ESM) version didn't support a package-level import. This would result in a runtime + typescript error:

```
import TriplyDb from "@triply/triplydb"
```

This PR fixes this, by adjusting the conditional package-level import