### PR TITLE
Implements two new methods on User objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ yarn-error.log
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+.env

--- a/src/User.ts
+++ b/src/User.ts
@@ -86,10 +86,7 @@ export default class User implements AccountBase {
     return this._info as Models.User;
   }
 
-  public async createOrganization(
-    accountName: string,
-    info?: Omit<Models.AccountUpdate, "pinnedDatasets" | "accountName">
-  ): Promise<Org> {
+  public async createOrganization(accountName: string, info?: NewOrganization): Promise<Org> {
     const newOrgJson = await _post<Routes.accounts._account.orgs.Post>({
       errorWithCleanerStack: getErr(
         `Failed to create organization ${accountName} and set ${this._name} as it's owner.`


### PR DESCRIPTION
It is currently difficult for programmers to write simple scripts that upload data to TriplyDB, because it is relatively difficult to create organizations in common programming scenarios.

An example of a simple use case:

- I want to create an organization called 'DBpedia-Association'.
- I want to create a dataset called 'DBpedia-2022-03'
- I want to do this with an API Token that is created for a specific (bot) user who is responsible for running the script.
This use case seems simple, but cannot be straightforwardly implemented:

- We can do `user.createOrganization('DBpedia-Association')`, but the second time we run the script, the organization already exists.
- We cannot easily check whether the organization already exists at the level of the user, because we must do `user.getOrganizations()` and then process the returned array/stream.
- We can do t`riply.getOrganization('DBpedia-Association')`, but that does not give us the information we need: user must also be a member of that organization in order to create a dataset within that organization.

This MR introduces:
- Add function `user.getOrganization(name: string)` that returns the organization in the same way as `triply.getOrganization(name: string)`, but within the scope of the user account (i.e. within the results otherwise returned by `user.getOrganizations()`).
- Add function `user.ensureOrganization(name: string, metadata: Object)` that allows a script to be rerun without having to try-catch around a block of `user.getOrganization()` and a block of `user.createOrganization()`.