### PR TITLE
Simplified exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,17 +107,8 @@
     "access": "public"
   },
   "exports": {
-    ".": {
-      "import": {
-        "types": "./lib/App.d.ts",
-        "default": "./lib/App.js"
-      }
-    },
-    "./*": {
-      "import": {
-        "default": "./lib/*"
-      }
-    }
+    ".": "./lib/App.js",
+    "./*":"./lib/*"
   },
   "type": "module"
 }


### PR DESCRIPTION
We've encountered issues when using TriplyDB-JS in a webpack context. This seems to be cause by webpack not supporting the full range of the `exports` package.json key (specifically, the conditional imports)

I simplified the configuration. This new configuration communicates the same thing as the more elaborate config.
I tested this new configuration on some repo's that use TriplyDB-JS, and there were no side-effects