### PR TITLE
Adds support for validating and submitting TriplyDB Datasets to the NDE Dataset Register.

### DIFF
--- a/src/Dataset.ts
+++ b/src/Dataset.ts
@@ -23,6 +23,7 @@ import Graph from "./Graph.js";
 import { stringify as stringifyQueryObj } from "query-string";
 import statuses from "http-status-codes";
 import { NamedNode } from "rdf-js";
+import NDEDatasetRegister from "./utils/NDEDatasetRegister.js";
 
 type JobDefaultsConfig = Omit<
   Routes.datasets._account._dataset.jobs.Post["Req"]["Body"],
@@ -578,98 +579,38 @@ export default class Dataset {
     return this._allPrefixes;
   }
 
-  private async apiNDEDatasetRegister(method: "validate" | "submit", next?: (shaclReport: n3.Store) => void) {
-    const info = await this.getInfo();
-    if (info.accessLevel !== "public") {
-      throw getErr(
-        `Only datasets with accesslevel 'public' can be submitted your dataset has accesslevel '${info.accessLevel}'.`
-      );
-    }
-    const { consoleUrl } = await this._app.getInfo();
-    const apiUrl =
-      "https://datasetregister.netwerkdigitaalerfgoed.nl/api/datasets" + (method === "validate" ? "/validate" : "");
-    const datasetURL = `${consoleUrl}/${info.owner.accountName}/${info.name}`;
-    const data = { "@id": datasetURL };
-    const init: RequestInit = {
-      method: method === "submit" ? "POST" : "PUT",
-      headers: {
-        "Content-Type": "application/ld+json",
-        Accept: "text/turtle",
-        Link: '<http://www.w3.org/ns/ldp#RDFSource>; rel="type",<http://www.w3.org/ns/ldp#Resource>; rel="type"',
-      },
-      body: JSON.stringify(data),
-    };
-    await fetch(apiUrl, init).then(async (rs) => {
-      const rs2store = async (): Promise<n3.Store> => {
-        const store = new n3.Store();
-        const parser = new n3.Parser();
-        parser.parse(await rs.text(), (error, quad) => {
-          if (error) {
-            throw getErr(
-              "Failed to load response from NDE Dataset Register API as valid Turtle. Please contact NDE about this issue."
-            );
-          } else if (quad) {
-            store.addQuad(quad);
-          }
-        });
-        return store;
-      };
-      if (!rs.ok) {
-        if (next && rs.status === 400) {
-          next(await rs2store());
-        } else
-          throw getErr(
-            `NDE Dataset Register reported: could not ${method} dataset '${info.displayName}'.\nPlease use their validation tool to see what might be wrong:\nhttps://datasetregister.netwerkdigitaalerfgoed.nl/validate.php?url=${datasetURL}`
-          );
-      } else if (next) {
-        next(await rs2store());
-      }
-    });
-  }
-
   public nde = {
     datasetregister: {
       /**
        * Register this dataset with the [NDE Dataset register](https://datasetregister.netwerkdigitaalerfgoed.nl/)
        *
-       * @param next an optional function that is called with the SHACL validation report as argument, if not provided an Error will be thrown when a dataset is not valid
+       * @param rejectOnValidationError an optional boolean (default = true) indicating that SHACL validation errors should throw an Error.
+       *                                If false, the function will not throw but return a Stroe containng the SHACL validation report.
        * @example
        * ```ts
        * App.get(token)
        *   .getAccount(accountName)
        *   .then(account => account.getDataset(datasetName))
-       *   .then(dataset => dataset.nde.datasetregister.submit((report) => {
-       *     if (report.size !== 2) {
-       *       console.error('Dataset is not valid.')
-       *     } else {
-       *       console.info('Dataset is valid.')
-       *     }
-       *   }))
-       *   .catch(e => console.error((e as Error).message))
+       *   .then(dataset => dataset.nde.datasetregister.submit())
        * ```
        */
-      submit: (next?: (shaclReport: n3.Store) => void) => this.apiNDEDatasetRegister("submit", next),
+      submit: async (rejectOnValidationError?: boolean) => NDEDatasetRegister(this, "submit", rejectOnValidationError),
 
       /**
        * Validate this dataset against the [NDE Dataset register](https://datasetregister.netwerkdigitaalerfgoed.nl/)
        *
-       * @param next an optional function that is called with the SHACL validation report as argument, if not provided an Error will be thrown when a dataset is not valid
+       * @param rejectOnValidationError an optional boolean (default = true) indicating that SHACL validation errors should throw an Error.
+       *                                If false, the function will not throw but return a Stroe containng the SHACL validation report.
        * @example
        * ```ts
        * App.get(token)
        *   .getAccount(accountName)
        *   .then(account => account.getDataset(datasetName))
-       *   .then(dataset => dataset.nde.datasetregister.validate((report) => {
-       *     if (report.size !== 2) {
-       *       console.error('Dataset is not valid.')
-       *     } else {
-       *       console.info('Dataset is valid.')
-       *     }
-       *   }))
-       *   .catch(e => console.error((e as Error).message))
+       *   .then(dataset => dataset.nde.datasetregister.submit())
        * ```
        */
-      validate: (next?: (shaclReport: n3.Store) => void) => this.apiNDEDatasetRegister("validate", next),
+      validate: async (rejectOnValidationError?: boolean) =>
+        NDEDatasetRegister(this, "validate", rejectOnValidationError),
     },
   };
 }

--- a/src/Dataset.ts
+++ b/src/Dataset.ts
@@ -619,7 +619,7 @@ export default class Dataset {
           next(await rs2store());
         } else
           throw getErr(
-            `NDE Dataset Register reported: could not ${method} dataset '${info.displayName}'.\nPlease use the validation tool to see what might be wrong:\nhttps://datasetregister.netwerkdigitaalerfgoed.nl/validate.php?url=${datasetURL}`
+            `NDE Dataset Register reported: could not ${method} dataset '${info.displayName}'.\nPlease use their validation tool to see what might be wrong:\nhttps://datasetregister.netwerkdigitaalerfgoed.nl/validate.php?url=${datasetURL}`
           );
       } else if (next) {
         next(await rs2store());

--- a/src/utils/NDEDatasetRegister.ts
+++ b/src/utils/NDEDatasetRegister.ts
@@ -1,0 +1,67 @@
+import n3 from "n3";
+import Dataset from "../Dataset.js";
+import { getErr } from "./Error.js";
+
+const response2store = async (rs: Response): Promise<n3.Store> => {
+  try {
+    return new n3.Store(new n3.Parser().parse(await rs.text()));
+  } catch (e) {
+    throw getErr("Failed to parse NDE Dataset Register response as valid RDF. Please contact NDE about this issue.");
+  }
+};
+
+export default async function NDEDatasetRegister(
+  dataset: Dataset,
+  method: "validate" | "submit",
+  rejectOnValidationError?: boolean
+): Promise<n3.Store> {
+  const info = await dataset.getInfo();
+  if (info.accessLevel !== "public") {
+    return Promise.reject(
+      getErr(
+        `Only datasets with accesslevel 'public' can be submitted your dataset has accesslevel '${info.accessLevel}'.`
+      )
+    );
+  }
+  const { consoleUrl } = await dataset["_app"].getInfo();
+  const datasetURL = `${consoleUrl}/${info.owner.accountName}/${info.name}`;
+  const apiUrl =
+    "https://datasetregister.netwerkdigitaalerfgoed.nl/api/datasets" + (method === "validate" ? "/validate" : "");
+  const data = { "@id": datasetURL };
+  const init: RequestInit = {
+    method: method === "submit" ? "POST" : "PUT",
+    headers: {
+      "Content-Type": "application/ld+json",
+      Accept: "text/turtle",
+      Link: '<http://www.w3.org/ns/ldp#RDFSource>; rel="type",<http://www.w3.org/ns/ldp#Resource>; rel="type"',
+    },
+    body: JSON.stringify(data),
+  };
+
+  let rs: Response;
+  try {
+    rs = await fetch(apiUrl, init);
+  } catch (e) {
+    throw getErr(`Could not connect to the NDE Dataset Register at ${apiUrl}.`);
+  }
+
+  if (rs.ok) {
+    return response2store(rs);
+  } else if (rs.status === 400) {
+    //this is a SHACL validation, we either throw or return the report (Store)
+    if (rejectOnValidationError ?? true) {
+      throw getErr(
+        `NDE Dataset Register reported: could not ${method} dataset '${info.displayName}' because of a SHACL validation error.\nPlease use their validation tool to see what might be wrong:\nhttps://datasetregister.netwerkdigitaalerfgoed.nl/validate.php?url=${datasetURL}`
+      );
+    } else {
+      return response2store(rs);
+    }
+  } else if (rs.status === 404) {
+    throw getErr(`NDE Dataset Register reported that the Dataset URL '${datasetURL}' can not be found.`);
+  } else {
+    //this not a SHACL validation error, but something else, point the user to their validation tool and throw
+    throw getErr(
+      `Could not ${method} dataset '${info.displayName}'.\nNDE Dataset Register reported: '${rs.statusText}' (code ${rs.status}).\nPlease use their validation tool to see what might be wrong:\nhttps://datasetregister.netwerkdigitaalerfgoed.nl/validate.php?url=${datasetURL}`
+    );
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "es2020",
     "moduleResolution": "node16",
     "declaration": true,
-
+    "declarationMap": true,
     "strict": true,
     "esModuleInterop": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
Example usage:

**case 1**: submit and throw Error if something goes wrong:
```ts
App.get(token)
 .getAccount(accountName)
  .then(account => account.getDataset(datasetName))
  .then(dataset => dataset.nde.datasetregister.submit())
  .catch(e => console.error((e as Error).message))
```

**case 2:** submit and use SHACL validation report as [N3](https://github.com/rdfjs/N3.js) Store to take further action:
```ts
App.get(token)
 .getAccount(accountName)
  .then(account => account.getDataset(datasetName))
  .then(dataset => dataset.nde.datasetregister.submit((report) => {
    if (report.size !== 2) {
      console.error('Dataset is not valid.')
    } else {
      console.info('Dataset is valid.')
    }
  }))
  .catch(e => console.error((e as Error).message))
```

The `submit()` function can be replaced with the `validate()` function, this does nit register the dataset itself, but only validates it against the SHACL shapes from the NDE Dataset Register.